### PR TITLE
Fixes after my initial run

### DIFF
--- a/8installer.sh
+++ b/8installer.sh
@@ -13,7 +13,7 @@ git clone https://github.com/ssilverm/pimame-8 pimame
 cd pimame
 git submodule init
 git submodule update
-sudo pip install flask pyyaml
+sudo pip install flask pyyaml python-levenshtein
 cp -r config/.advance/ ~/
 sudo cp config/vsftpd.conf /etc/
 sudo cp config/inittab /etc/


### PR DESCRIPTION
I encountered a number of issues when I initially pulled down and ran the 8installer.sh script tonight, which included:
- Starting within the pimame_installer directory, and thus relative paths screwed everything up.
- Genesis roms paths was missing the pimame directory
- Scraper didn't work

I'm unsure about the pip-install python-levenshtein as I note you have this in the build/ of pimame-menu, but adding this step enabled scraper to work for me.
